### PR TITLE
Refactor middleware to validate auth_token session

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,21 +1,48 @@
 // middleware.ts
 import { NextRequest, NextResponse } from "next/server";
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const isLogin = pathname.startsWith("/login");
   const isPublic = pathname === "/" || isLogin;
 
-  // Cookie user para autenticação
-  const userCookie = request.cookies.get("user")?.value;
-
   // Permite acesso às páginas públicas
   if (isPublic) return NextResponse.next();
 
-  // Rotas protegidas (exemplo)
-  if (!userCookie) {
+  // Verifica se existe token de autenticação
+  const authToken = request.cookies.get("auth_token")?.value;
+  if (!authToken) {
     const url = request.nextUrl.clone();
-    url.pathname = "/login";
+    url.pathname = "/";
+    return NextResponse.redirect(url);
+  }
+
+  try {
+    const sessionResponse = await fetch(
+      `${request.nextUrl.origin}/api/auth/session`,
+      {
+        headers: {
+          cookie: `auth_token=${authToken}`,
+        },
+      }
+    );
+
+    if (!sessionResponse.ok) {
+      const url = request.nextUrl.clone();
+      url.pathname = "/";
+      return NextResponse.redirect(url);
+    }
+
+    const session = await sessionResponse.json();
+    const isAuthenticated = session?.user || session?.authenticated;
+    if (!isAuthenticated) {
+      const url = request.nextUrl.clone();
+      url.pathname = "/";
+      return NextResponse.redirect(url);
+    }
+  } catch {
+    const url = request.nextUrl.clone();
+    url.pathname = "/";
     return NextResponse.redirect(url);
   }
 


### PR DESCRIPTION
## Summary
- verify auth session using `auth_token` cookie via `/api/auth/session`
- redirect unauthenticated users to the home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `CI=true npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c9941c248326a5eb6c1eb8b34708