### PR TITLE
refactor: simplify tailwind content paths

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   darkMode: "class",
-  content: [
-    "./src/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-  ],
+  content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- simplify TailwindCSS content glob to scan entire `src`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint .` *(fails: ESLint couldn't find the config "next/typescript" to extend from)*
- `npm run build` *(fails: Page config in `src/app/api/import/dxf/route.ts` is deprecated)*
- `npx tailwindcss --input src/app/globals.css --content "./src/**/*.{js,ts,jsx,tsx,mdx}" --minify -o /tmp/tw.css`
- `grep -o "bg-red-500" /tmp/tw.css | head`
- `grep -o "bg-pink-500" /tmp/tw.css | head`


------
https://chatgpt.com/codex/tasks/task_e_68a5cd791154832681727cb130152521