### PR TITLE
chore: tighten TypeScript compile settings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
+    "allowJs": false,
+    "skipLibCheck": false,
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- disable JavaScript compilation and enable library type checking

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit` *(fails: node_modules/lucide-react/dist/lucide-react.d.ts(1,10): error TS2305: Module '"react"' has no exported member 'ReactSVG'.)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cfdeb04483269d23ad8672782384