### PR TITLE
feat: replace PowerShell backup with Node scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,20 @@ Execute a suíte de testes:
 npm test
 ```
 
+## Backup
+
+Crie um snapshot do repositório (git bundle) executando:
+
+```bash
+npm run backup
+```
+
+O bundle será salvo em `backups/` com timestamp. Para também enviar as alterações ao remoto padrão, utilize:
+
+```bash
+npm run backup -- --push
+```
+
 ## Contribuição
 
 1. Faça um fork do projeto.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest"
+    "test": "vitest",
+    "backup": "node run-backup.js"
   },
   "dependencies": {
     "@tarikjabiri/dxf": "^2.8.9",

--- a/run-backup.js
+++ b/run-backup.js
@@ -2,20 +2,10 @@
 const { spawn } = require('child_process');
 const path = require('path');
 
-const script = path.join(__dirname, 'scripts', 'backup-and-push.ps1');
+const script = path.join(__dirname, 'scripts', 'backup-and-push.js');
+// Pass through additional CLI args, default to creating a bundle
+const extraArgs = process.argv.slice(2);
+const args = [script, '--create-bundle', ...extraArgs];
 
-function run(shell) {
-  const args = ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', script, '-CreateBundle'];
-  const child = spawn(shell, args, { stdio: 'inherit' });
-  child.on('error', (err) => {
-    if (shell === 'pwsh') {
-      run(process.platform === 'win32' ? 'powershell' : 'powershell');
-    } else {
-      console.error('[x] Nenhum PowerShell encontrado (pwsh/powershell).');
-      process.exit(1);
-    }
-  });
-  child.on('exit', (code) => process.exit(code ?? 0));
-}
-
-run('pwsh');
+const child = spawn(process.execPath, args, { stdio: 'inherit' });
+child.on('exit', (code) => process.exit(code ?? 0));

--- a/scripts/backup-and-push.js
+++ b/scripts/backup-and-push.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function run(cmd, args, options = {}) {
+  const result = spawnSync(cmd, args, { stdio: 'inherit', ...options });
+  if (result.error) {
+    console.error(`[x] ${result.error.message}`);
+    process.exit(1);
+  }
+  if (result.status !== 0) {
+    process.exit(result.status);
+  }
+  return result;
+}
+
+function capture(cmd, args, options = {}) {
+  const result = spawnSync(cmd, args, { stdio: ['inherit', 'pipe', 'inherit'], ...options });
+  if (result.error) {
+    console.error(`[x] ${result.error.message}`);
+    process.exit(1);
+  }
+  if (result.status !== 0) {
+    process.exit(result.status);
+  }
+  return result.stdout.toString().trim();
+}
+
+const argv = process.argv.slice(2);
+const opts = {
+  createBundle: false,
+  runPushScript: false,
+  bundleDir: path.join(process.cwd(), 'backups'),
+};
+
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i];
+  switch (a) {
+    case '--create-bundle':
+    case '-b':
+      opts.createBundle = true;
+      break;
+    case '--run-push-script':
+    case '--push':
+    case '-p':
+      opts.runPushScript = true;
+      break;
+    case '--bundle-dir':
+      opts.bundleDir = argv[++i] || opts.bundleDir;
+      break;
+    default:
+      break;
+  }
+}
+
+// Ensure git is available
+try {
+  run('git', ['--version']);
+} catch (e) {
+  console.error('[x] git não encontrado no PATH.');
+  process.exit(1);
+}
+
+const repoRoot = capture('git', ['rev-parse', '--show-toplevel']);
+process.chdir(repoRoot);
+
+if (opts.createBundle) {
+  const dir = path.resolve(opts.bundleDir);
+  fs.mkdirSync(dir, { recursive: true });
+  const repoName = path.basename(repoRoot);
+  const stamp = new Date().toISOString().replace(/[:T]/g, '-').split('.')[0];
+  const bundleFile = path.join(dir, `${repoName}-${stamp}.bundle`);
+  run('git', ['bundle', 'create', bundleFile, '--all']);
+  console.log(`[i] Bundle criado em: ${bundleFile}`);
+}
+
+if (opts.runPushScript) {
+  const pushScript = path.join(__dirname, 'push-to-github.js');
+  const res = spawnSync(process.execPath, [pushScript], { stdio: 'inherit' });
+  if (res.error) {
+    console.error(`[x] ${res.error.message}`);
+    process.exit(1);
+  }
+  process.exit(res.status ?? 0);
+}

--- a/scripts/push-to-github.js
+++ b/scripts/push-to-github.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+const { spawnSync } = require('child_process');
+
+function run(cmd, args, options = {}) {
+  const result = spawnSync(cmd, args, { stdio: 'inherit', ...options });
+  if (result.error) {
+    console.error(`[x] ${result.error.message}`);
+    process.exit(1);
+  }
+  if (result.status !== 0) {
+    process.exit(result.status);
+  }
+  return result;
+}
+
+function capture(cmd, args, options = {}) {
+  const result = spawnSync(cmd, args, { stdio: ['inherit', 'pipe', 'inherit'], ...options });
+  if (result.error) {
+    console.error(`[x] ${result.error.message}`);
+    process.exit(1);
+  }
+  if (result.status !== 0) {
+    process.exit(result.status);
+  }
+  return result.stdout.toString().trim();
+}
+
+try {
+  run('git', ['--version']);
+} catch (e) {
+  console.error('[x] git não encontrado no PATH.');
+  process.exit(1);
+}
+
+run('git', ['add', '-A']);
+const status = capture('git', ['status', '--porcelain']);
+if (status) {
+  const msg = `Backup: ${new Date().toISOString().replace(/T/, ' ').split('.')[0]}`;
+  run('git', ['commit', '-m', msg]);
+}
+run('git', ['push']);


### PR DESCRIPTION
## Summary
- rewrite run-backup to call new cross-platform Node backup script
- add backup-and-push and push-to-github utilities in Node
- document npm run backup usage and expose script in package.json

## Testing
- `npm run backup`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5f5587754832690a0c2b43a76eb0d