### PR TITLE
Enable React strict mode and SWC minification

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,11 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // Ative experimental se precisar:
-  // experimental: { appDir: true },
-  // Outras configurações opcionais:
-  // reactStrictMode: true,
-  // swcMinify: true,
-  // images: { domains: ["..."] },
+  reactStrictMode: true,
+  swcMinify: true,
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- enable React strict mode and Next.js SWC minifier

## Testing
- `npm run dev`
- `npm run build` *(fails: Page config in src/app/api/import/dxf/route.ts is deprecated)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f55b7bdc832689749fe18bdedc7d