### PR TITLE
docs: remove public login env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,11 +3,7 @@
 # Chave da API do OpenAI
 OPENAI_API_KEY=
 
-# Credenciais para login (lado do cliente)
-NEXT_PUBLIC_LOGIN_EMAIL=
-NEXT_PUBLIC_LOGIN_SENHA=
-
-# Credenciais para login (lado do servidor)
+# Credenciais para login (usadas apenas no servidor)
 LOGIN_EMAIL=
 LOGIN_SENHA=
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Copie o arquivo de exemplo de variáveis de ambiente:
 cp .env.example .env.local
 ```
 
-Edite `.env.local` e preencha os valores conforme seu ambiente.
+Edite `.env.local` e preencha os valores conforme seu ambiente. Defina `LOGIN_EMAIL` e `LOGIN_SENHA` com as credenciais de acesso; essas variáveis são usadas apenas no servidor e não são expostas ao cliente.
 
 ## Uso
 


### PR DESCRIPTION
## Summary
- remove client login variables from env example
- clarify server-side login credentials usage

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f556f6cc8326a8f21e3e2fb67a15