### PR TITLE
Switch session cookie to auth token

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,6 @@
 // middleware.ts
 import { NextRequest, NextResponse } from "next/server";
+import { AUTH_COOKIE } from "@/lib/auth";
 
 function redirectToLogin(request: NextRequest) {
   const url = request.nextUrl.clone();
@@ -16,14 +17,14 @@ export async function middleware(request: NextRequest) {
   if (isPublic) return NextResponse.next();
 
   // Verifica se existe token de autenticação
-  const authToken = request.cookies.get("auth_token")?.value;
+  const authToken = request.cookies.get(AUTH_COOKIE)?.value;
   if (!authToken) {
     return redirectToLogin(request);
   }
 
   try {
     const sessionResponse = await fetch(
-      `${request.nextUrl.origin}/api/auth/session`,
+      `${request.nextUrl.origin}/api/session`,
       {
         headers: {
           cookie: request.headers.get("cookie") ?? "",

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { randomBytes } from "crypto";
+import { AUTH_COOKIE } from "@/lib/auth";
 
 const EMAIL = process.env.LOGIN_EMAIL;         // NÃO usar NEXT_PUBLIC_ aqui
 const SENHA = process.env.LOGIN_SENHA;
@@ -15,9 +17,9 @@ export async function POST(req: NextRequest) {
     const { usuario, senha } = await req.json();
 
     if (usuario === EMAIL && senha === SENHA) {
+      const token = randomBytes(32).toString("hex");
       const res = NextResponse.json({ success: true }, { status: 200 });
-      // Cookie HttpOnly contendo o email (para leitura server-side)
-      res.cookies.set("session", encodeURIComponent(usuario), {
+      res.cookies.set(AUTH_COOKIE, token, {
         httpOnly: true,
         secure: process.env.NODE_ENV === "production",
         sameSite: "strict",

--- a/src/app/api/logout/route.ts
+++ b/src/app/api/logout/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
+import { AUTH_COOKIE } from "@/lib/auth";
 
 export async function POST() {
   const res = NextResponse.json({ success: true }, { status: 200 });
-  res.cookies.set("session", "", {
+  res.cookies.set(AUTH_COOKIE, "", {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: "strict",

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
+import { AUTH_COOKIE } from "@/lib/auth";
 
 export async function GET() {
   const jar = cookies();
-  const session = jar.get("session")?.value;
-  if (!session) {
+  const token = jar.get(AUTH_COOKIE)?.value;
+  if (!token) {
     return NextResponse.json({ authenticated: false }, { status: 200 });
   }
-  return NextResponse.json({ authenticated: true, email: decodeURIComponent(session) }, { status: 200 });
+  return NextResponse.json({ authenticated: true }, { status: 200 });
 }

--- a/src/app/restricted/page.tsx
+++ b/src/app/restricted/page.tsx
@@ -1,10 +1,11 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { AUTH_COOKIE } from "@/lib/auth";
 
 export default async function RestrictedPage() {
   const jar = cookies();
-  const session = jar.get("session")?.value;
-  if (!session) redirect("/login");
+  const token = jar.get(AUTH_COOKIE)?.value;
+  if (!token) redirect("/login");
 
   // Conteúdo restrito
   return (

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,1 @@
+export const AUTH_COOKIE = "auth_token";


### PR DESCRIPTION
## Summary
- define `AUTH_COOKIE` constant for auth token cookie
- store random token on login and check standardized cookie across logout and session APIs
- verify new cookie in middleware and restricted page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a601ed8ebc832698bd096ece5a3b11