### PR TITLE
docs: clarify cookie secure usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ OPENAI_API_KEY=
 # Credenciais para login (usadas apenas no servidor)
 LOGIN_EMAIL=
 LOGIN_SENHA=
+# O cookie de autenticação usa `secure: process.env.NODE_ENV === "production"`.
+# Em desenvolvimento local sem HTTPS, mantenha NODE_ENV diferente de "production".
 
 # Caminho para o executável ODA File Converter
 ODA_CONVERTER=

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -22,7 +22,7 @@ export async function POST(req: NextRequest) {
       const res = NextResponse.json({ success: true }, { status: 200 });
       res.cookies.set("auth_token", token, {
         httpOnly: true,
-        secure: process.env.NODE_ENV === "production",
+        secure: process.env.NODE_ENV === "production", // usa cookie secure apenas em produção (HTTPS)
         sameSite: "strict",
         path: "/",
         maxAge: 60 * 60, // 1h


### PR DESCRIPTION
## Summary
- document auth cookie secure behavior in env example
- explain NODE_ENV HTTPS requirement in login route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6194a8d008326a36bf263ba11a302