### PR TITLE
Log auth token and session response in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -17,20 +17,25 @@ export async function middleware(request: NextRequest) {
   }
 
   const authToken = request.cookies.get("auth_token")?.value;
+  console.log("auth_token recebido:", authToken);
   if (!authToken) {
     return redirectToLogin(request);
   }
 
   try {
     const sessionResponse = await fetch(
-      `${request.nextUrl.origin}/api/auth/session`,
-      {
-        headers: {
-          cookie: request.headers.get("cookie") ?? "",
-        },
-        cache: "no-store",
-      }
-    );
+        `${request.nextUrl.origin}/api/auth/session`,
+        {
+          headers: {
+            cookie: request.headers.get("cookie") ?? "",
+          },
+          cache: "no-store",
+        }
+      );
+
+    console.log("status /api/auth/session:", sessionResponse.status);
+    const sessionPayload = await sessionResponse.clone().json();
+    console.log("payload /api/auth/session:", sessionPayload);
 
     if (!sessionResponse.ok) {
       return redirectToLogin(request);


### PR DESCRIPTION
## Summary
- log received `auth_token` cookie when processing requests in middleware
- output `/api/auth/session` response status and payload for debugging

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a62ea18ba483269c0dbc82016669a0