### PR TITLE
test: isolate middleware fetch mock

### DIFF
--- a/tests/unit/middleware.test.ts
+++ b/tests/unit/middleware.test.ts
@@ -1,11 +1,20 @@
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { middleware } from "../../middleware";
 
 describe("middleware", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(global, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
   test("rotas públicas não disparam verificação de sessão", async () => {
     const request = new NextRequest("http://localhost/");
-    const fetchSpy = vi.spyOn(global, "fetch");
 
     const response = await middleware(request);
 


### PR DESCRIPTION
## Summary
- ensure middleware unit tests isolate fetch spy in beforeEach/afterEach

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a6346281ec8326a07a6558dc1bad0c