### PR TITLE
Centralize auth cookie management

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { randomBytes } from "crypto";
 import tokenStore from "@/lib/authStore";
+import { setAuthCookie } from "@/lib/cookieUtils";
 
 const EMAIL = process.env.LOGIN_EMAIL; // NÃO usar NEXT_PUBLIC_ aqui
 const SENHA = process.env.LOGIN_SENHA;
@@ -19,15 +20,8 @@ export async function POST(req: NextRequest) {
     if (email === EMAIL && senha === SENHA) {
       const token = randomBytes(32).toString("hex");
       tokenStore.set(token, email);
-      const res = NextResponse.json({ success: true }, { status: 200 });
-      res.cookies.set("auth_token", token, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === "production", // usa cookie secure apenas em produção (HTTPS)
-        sameSite: "strict",
-        path: "/",
-        maxAge: 60 * 60, // 1h
-      });
-      return res;
+      setAuthCookie(token);
+      return NextResponse.json({ success: true }, { status: 200 });
     }
 
     return NextResponse.json(

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import tokenStore from "@/lib/authStore";
+import { setAuthCookie } from "@/lib/cookieUtils";
 
 export async function POST() {
   const jar = cookies();
@@ -8,13 +9,6 @@ export async function POST() {
   if (token) {
     tokenStore.delete(token);
   }
-  const res = NextResponse.json({ success: true }, { status: 200 });
-  res.cookies.set("auth_token", "", {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: "strict",
-    path: "/",
-    maxAge: 0,
-  });
-  return res;
+  setAuthCookie("", 0);
+  return NextResponse.json({ success: true }, { status: 200 });
 }

--- a/src/lib/cookieUtils.ts
+++ b/src/lib/cookieUtils.ts
@@ -1,0 +1,11 @@
+import { cookies } from "next/headers";
+
+export function setAuthCookie(value: string, maxAge = 60 * 60) {
+  cookies().set("auth_token", value, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "strict",
+    path: "/",
+    maxAge,
+  });
+}

--- a/tests/unit/auth.routes.test.ts
+++ b/tests/unit/auth.routes.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/cookieUtils", () => ({
+  setAuthCookie: vi.fn((value: string, maxAge = 60 * 60) => {
+    // default implementation preserves signature
+  }),
+}));
+vi.mock("next/headers", () => ({ cookies: vi.fn() }));
+
+import tokenStore from "@/lib/authStore";
+import { setAuthCookie } from "@/lib/cookieUtils";
+import { cookies } from "next/headers";
+
+const mockedSetAuthCookie = vi.mocked(setAuthCookie);
+const mockedCookies = vi.mocked(cookies);
+
+describe("auth routes", () => {
+  beforeEach(() => {
+    tokenStore.clear();
+    mockedSetAuthCookie.mockReset();
+    mockedCookies.mockReset();
+  });
+
+  test("login sets auth cookie and stores token", async () => {
+    process.env.LOGIN_EMAIL = "user@example.com";
+    process.env.LOGIN_SENHA = "secret";
+    const { POST: login } = await import("@/app/api/auth/login/route");
+    const req = { json: async () => ({ email: "user@example.com", senha: "secret" }) } as any;
+    const res = await login(req);
+    expect(res.status).toBe(200);
+    const token = Array.from(tokenStore.keys())[0];
+    expect(tokenStore.get(token)).toBe("user@example.com");
+    expect(mockedSetAuthCookie).toHaveBeenCalledWith(token);
+  });
+
+  test("logout clears auth cookie and token", async () => {
+    const token = "abc123";
+    tokenStore.set(token, "user@example.com");
+    mockedCookies.mockReturnValue({ get: () => ({ value: token }) } as any);
+    const { POST: logout } = await import("@/app/api/auth/logout/route");
+    const res = await logout();
+    expect(res.status).toBe(200);
+    expect(tokenStore.size).toBe(0);
+    expect(mockedSetAuthCookie).toHaveBeenCalledWith("", 0);
+  });
+});


### PR DESCRIPTION
## Summary
- add utility to manage auth cookies via `next/headers`
- update login/logout API routes to use new cookie helper
- mock cookie utilities in tests instead of next/headers modules

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a63818e928832680061bb51ca58927