### PR TITLE
chore: update TypeScript target to ES2022

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": false,
     "skipLibCheck": false,


### PR DESCRIPTION
## Summary
- target modern Node/JS features by setting TypeScript target to `ES2022`

## Testing
- `npx tsc --noEmit --pretty false` *(fails: numerous type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a65c53d06c832697199e0eef466f67