### PR TITLE
Add security headers to Next.js configuration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,35 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: "default-src 'self'"
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff'
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY'
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'no-referrer'
+          },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=31536000; includeSubDomains; preload'
+          }
+        ]
+      }
+    ];
+  }
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- serve standard security headers via `headers()` in `next.config.js`

## Testing
- `npm test`
- `npm run lint`
- `npm run dev` and `curl -sI http://127.0.0.1:3000/`

------
https://chatgpt.com/codex/tasks/task_e_68a66c40e1c48326aef90055f4a40946